### PR TITLE
Feature: Fix assembly version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
             env VERSION "$($SCRIPTS/get_json_version.sh ./ci/version.json FULL)"
             env VERSION_SUFFIX "$($SCRIPTS/get_json_version.sh ./ci/version.json SUFFIX)"
             env VERSION_JSON_NET "$($SCRIPTS/get_json_version.sh ./ci/version.json JSON_NET)"
+            env VERSION_ASSEMBLY "$($SCRIPTS/get_json_version.sh ./ci/version.json ASSEMBLY)"
             echo
 
             echo ">>> UPDATING VERSION IN $(pwd)/Src/Newtonsoft.Json-for-Unity/package.json"

--- a/Src/Newtonsoft.Json-for-Unity/CHANGELOG.md
+++ b/Src/Newtonsoft.Json-for-Unity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Newtonsoft.Json for Unity changelog
 
+## 12.0.102
+
+- Fixed to use only major version in assembly version (ex: `12.0.0.0`, instead of `12.0.1.0`)
+
 ## 12.0.101
 
 ## Changes

--- a/Src/Newtonsoft.Json-for-Unity/CHANGELOG.md
+++ b/Src/Newtonsoft.Json-for-Unity/CHANGELOG.md
@@ -6,23 +6,12 @@
 
 ## 12.0.101
 
-## Changes
-
 - Setup CircleCI integration
 - Setup Codacy integration
 - Switched to [cloudsmith.com][cloudsmith-url] as registry provider
 - New versioning format. For more info see [the readme in the repository][readme-url]. Changes are based of off `12.0.1-patch-001` version _(in previous format)._
-
-## 12.0.1-patch-001
-
 - Fixed building on standalone ([Issue #3][issue3])
-
-## 12.0.1
-
-- Initial release
-- Deployed to [npmjs.com][npm-url]
 
 [readme-url]: https://github.com/jilleJr/Newtonsoft.Json-for-Unity#readme
 [cloudsmith-url]: https://cloudsmith.io/~jillejr/repos/newtonsoft-json-for-unity
-[npm-url]: https://www.npmjs.com/package/jillejr.newtonsoft.json-for-unity
 [issue3]: https://github.com/jilleJr/Newtonsoft.Json-for-Unity/issues/3

--- a/ci/local_build_into_package.ps1
+++ b/ci/local_build_into_package.ps1
@@ -70,6 +70,7 @@ try {
     env VERSION "$($SCRIPTS/get_json_version.sh ./ci/version.json FULL)"
     env VERSION_SUFFIX "$($SCRIPTS/get_json_version.sh ./ci/version.json SUFFIX)"
     env VERSION_JSON_NET "$($SCRIPTS/get_json_version.sh ./ci/version.json JSON_NET)"
+    env VERSION_ASSEMBLY "$($SCRIPTS/get_json_version.sh ./ci/version.json ASSEMBLY)"
     echo
     
     echo ">>> UPDATING VERSION IN $(pwd)/Src/Newtonsoft.Json-for-Unity/package.json"

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -11,6 +11,7 @@ BUILD_DESTINATION=${3:-${BUILD_DESTINATION:-"${BUILD_DESTINATION_BASE:?"Build ou
 
 : ${VERSION:?"Full version required."}
 : ${VERSION_JSON_NET:?"Json.NET version required."}
+: ${VERSION_ASSEMBLY:?"Assembly version required."}
 : ${VERSION_SUFFIX:?"Version suffix required."}
 : ${BUILD_CONFIGURATION:="Release"}
 
@@ -40,7 +41,7 @@ msbuild -t:build "$BUILD_SOLUTION" \
     -p:UnityBuild="$BUILD_UNITY" \
     -p:VersionPrefix="$VERSION_JSON_NET" \
     -p:VersionSuffix="$VERSION_SUFFIX" \
-    -p:AssemblyVersion="$VERSION_JSON_NET" \
+    -p:AssemblyVersion="$VERSION_ASSEMBLY" \
     -p:FileVersion="$VERSION"
 
 echo

--- a/ci/scripts/get_json_version.sh
+++ b/ci/scripts/get_json_version.sh
@@ -45,6 +45,9 @@ FULL)
 JSON_NET)
     jq2 -er '(.Major // 0|tostring) + "." + (.Minor // 0|tostring) + "." + (.Patch // 0|tostring)' "$jsonFile"
     ;;
+ASSEMBLY)
+    jq2 -er '(.Major // 0|tostring) + ".0.0.0"' "$jsonFile"
+    ;;
 SUFFIX)
     release="$(jq2 -er '.Release // empty' "$jsonFile")"
     
@@ -61,7 +64,7 @@ RELEASE)
     ;;
 *)
     error "Error: Unknown output type '$output'
-    Possible values: FULL, JSON_NET, SUFFIX, RELEASE"
+    Possible values: FULL, JSON_NET, ASSEMBLY, SUFFIX, RELEASE"
     exit 3
     ;;
 esac

--- a/ci/version.json
+++ b/ci/version.json
@@ -3,5 +3,5 @@
   "Minor": 0,
   "Patch": 1,
 
-  "Release": 1
+  "Release": 2
 }


### PR DESCRIPTION
To quote #18:

> ## _Expected behavior_
>
> _Assembly version for 12.0.101 release is **`12.0.0.0`**_
>
> ## _Actual behavior_
>
> _Assembly version for 12.0.101 release is **`12.0.1.0`**_
> 
> (https://github.com/jilleJr/Newtonsoft.Json-for-Unity/issues/18)

This resolves #18 by changing the built assembly version to be only based on major versioning; matching Json.<i></i>NET in the process.