### PR TITLE
Feature/ease on the auto deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,15 +474,13 @@ workflows:
       - test-unity-2019-2-11f1:
           requires:
             - build-package
-      - hold:
-          type: approval
+      - deploy-cloudsmith:
           requires:
             - test-windows
             - test-unity-2018-4-14f1
             - test-unity-2019-2-11f1
-      - deploy-cloudsmith:
-          requires:
-            - hold
       - deploy-github:
           requires:
-            - hold
+            - test-windows
+            - test-unity-2018-4-14f1
+            - test-unity-2019-2-11f1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
 
       - run:
           name: Setup variables
-          command: $SCRIPTS/build_setup_variables.sh json true
+          command: $SCRIPTS/build_setup_variables.sh json true $REPO_FOLDER/ci/version.json
       - run:
           name: NuGet restore
           command: |
@@ -82,7 +82,7 @@ jobs:
 
       - run:
           name: Setup variables for Newtonsoft.Json.Tests
-          command: $SCRIPTS/build_setup_variables.sh xml false
+          command: $SCRIPTS/build_setup_variables.sh xml false $REPO_FOLDER/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
 
       - run:
           name: Build Newtonsoft.Json.Tests for Unity
@@ -342,7 +342,7 @@ jobs:
 
       - run:
           name: Setup Variables
-          command: $SCRIPTS/build_setup_variables.sh json false
+          command: $SCRIPTS/build_setup_variables.sh json false $REPO_FOLDER/ci/version.json
 
       - run:
           name: NPM Login
@@ -399,7 +399,7 @@ jobs:
 
       - run:
           name: Setup Variables
-          command: $SCRIPTS/build_setup_variables.sh json false
+          command: $SCRIPTS/build_setup_variables.sh json false $REPO_FOLDER/ci/version.json
 
       - run:
           name: Deploy
@@ -427,7 +427,7 @@ jobs:
 
       - run:
           name: Setup Variables
-          command: $SCRIPTS/build_setup_variables.sh json false
+          command: $SCRIPTS/build_setup_variables.sh json false $REPO_FOLDER/ci/version.json
 
       - run:
           name: Check if release is ready for deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ preset-filter-check: &WORKFLOW_CHECK_DEPLOY_READY_FILTER
   only:
     - /^hotfix.*/
     - /^release.*/
+    - /^feature.*/
 
 orbs:
   win: circleci/windows@2.3.0
@@ -474,13 +475,14 @@ workflows:
       - test-unity-2019-2-11f1:
           requires:
             - build-package
+      - check-deploy-ready:
+          requires:
+            - test-windows
+            - test-unity-2018-4-14f1
+            - test-unity-2019-2-11f1
       - deploy-cloudsmith:
           requires:
-            - test-windows
-            - test-unity-2018-4-14f1
-            - test-unity-2019-2-11f1
+            - check-deploy-ready
       - deploy-github:
           requires:
-            - test-windows
-            - test-unity-2018-4-14f1
-            - test-unity-2019-2-11f1
+            - check-deploy-ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
       REPO_FOLDER: /root/repo
 
     docker:
-      - image: applejag/newtonsoft.json-for-unity.package-deploy-github:v5
+      - image: applejag/newtonsoft.json-for-unity.package-deploy-github:v6
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ jobs:
             if [ -z "$(npm view jillejr.newtonsoft.json-for-unity@$VERSION versions)" ]
             then
               cd /workspace/package
-              if [ "${VERSION_AUTO_DEPLOY_DRY_RUN:-}" == "false" ]
+              if [ "${VERSION_AUTO_DEPLOY_LIVE_RUN:-}" == "true" ]
               then
                 npm publish
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,28 +47,7 @@ jobs:
 
       - run:
           name: Setup variables
-          command: |
-            env() {
-              echo "export '$1=$2'" >> $BASH_ENV
-              echo "$1='$2'"
-              export "$1=$2"
-            }
-            echo ">>> OBTAINING VERSION FROM $(pwd)/ci/version.json"
-            env VERSION "$($SCRIPTS/get_json_version.sh ./ci/version.json FULL)"
-            env VERSION_SUFFIX "$($SCRIPTS/get_json_version.sh ./ci/version.json SUFFIX)"
-            env VERSION_JSON_NET "$($SCRIPTS/get_json_version.sh ./ci/version.json JSON_NET)"
-            env VERSION_ASSEMBLY "$($SCRIPTS/get_json_version.sh ./ci/version.json ASSEMBLY)"
-            echo
-
-            echo ">>> UPDATING VERSION IN $(pwd)/Src/Newtonsoft.Json-for-Unity/package.json"
-            echo "BEFORE:"
-            echo ".version=$(jq ".version" Src/Newtonsoft.Json-for-Unity/package.json)"
-            echo ".displayName=$(jq ".displayName" Src/Newtonsoft.Json-for-Unity/package.json)"
-            echo "$(jq ".version=\"$VERSION\" | .displayName=\"Json.NET $VERSION_JSON_NET for Unity\"" Src/Newtonsoft.Json-for-Unity/package.json)" > Src/Newtonsoft.Json-for-Unity/package.json
-            echo "AFTER:"
-            echo ".version=$(jq ".version" Src/Newtonsoft.Json-for-Unity/package.json)"
-            echo ".displayName=$(jq ".displayName" Src/Newtonsoft.Json-for-Unity/package.json)"
-
+          command: $SCRIPTS/build_setup_variables.sh json true
       - run:
           name: NuGet restore
           command: |
@@ -102,20 +81,7 @@ jobs:
 
       - run:
           name: Setup variables for Newtonsoft.Json.Tests
-          command: |
-            env() {
-                echo "export '$1=$2'" >> $BASH_ENV
-                echo "$1='$2'"
-                export "$1=$2"
-            }
-            xml() {
-                xmlstarlet sel -t -v "/Project/PropertyGroup/$1" -n Src/Newtonsoft.Json/Newtonsoft.Json.csproj | head -n 1
-            }
-            echo ">>> OBTAINING VERSION FROM $(pwd)/Src/Newtonsoft.Json/Newtonsoft.Json.csproj"
-            env VERSION "$(xml VersionPrefix)"
-            env VERSION_SUFFIX "$(xml VersionSuffix)"
-            env VERSION_JSON_NET "$(xml VersionPrefix)"
-            env VERSION_ASSEMBLY "$(xml AssemblyVersion)"
+          command: $SCRIPTS/build_setup_variables.sh xml false
 
       - run:
           name: Build Newtonsoft.Json.Tests for Unity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
       - checkout
 
       - attach_workspace:
-        at: /workspace
+          at: /workspace
 
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,17 +5,18 @@ preset-filter-test: &WORKFLOW_BUILD_TEST_FILTER
     - develop
     - /^hotfix.*/
     - /^release.*/
+    # - /^feature.*/
 
 preset-filter-deploy: &WORKFLOW_BUILD_TEST_DEPLOY_FILTER
   only:
     - master
-    - /^feature.*/
+    - /^feature.*/ #temporarily added here
 
 preset-filter-check: &WORKFLOW_CHECK_DEPLOY_READY_FILTER
   only:
     - /^hotfix.*/
     - /^release.*/
-    - /^feature.*/
+    # - /^feature.*/
 
 orbs:
   win: circleci/windows@2.3.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,10 @@ jobs:
 
       - run:
           name: Setup variables
-          command: $SCRIPTS/build_setup_variables.sh json true $REPO_FOLDER/ci/version.json
+          command: |
+            $SCRIPTS/build_setup_variables.sh json true \
+              $REPO_FOLDER/ci/version.json \
+              $REPO_FOLDER/Src/Newtonsoft.Json-for-Unity/package.json
       - run:
           name: NuGet restore
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
       REPO_FOLDER: /root/repo
 
     docker:
-      - image: applejag/newtonsoft.json-for-unity.package-deploy-github:v4
+      - image: applejag/newtonsoft.json-for-unity.package-deploy-github:v5
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 preset-filter-test: &WORKFLOW_BUILD_TEST_FILTER
   only:
     - develop
-    - /^feature.*/
     - /^hotfix.*/
     - /^release.*/
 
 preset-filter-deploy: &WORKFLOW_BUILD_TEST_DEPLOY_FILTER
   only:
     - master
+    - /^feature.*/
 
 preset-filter-check: &WORKFLOW_CHECK_DEPLOY_READY_FILTER
   only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,10 @@ orbs:
 jobs:
   build-package:
     working_directory: ~/repo
-    
+
     environment:
       SCRIPTS: /root/repo/ci/scripts
+      REPO_FOLDER: /root/repo
       BUILD_SOLUTION: /root/repo/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
       TEST_SOLUTION: /root/repo/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
       BUILD_DESTINATION_BASE: /root/repo/Src/Newtonsoft.Json-for-Unity/Plugins
@@ -166,7 +167,7 @@ jobs:
           name: Convert NUnit to JUnit xml
           when: always
           command: ci/scripts/nunit2junit.ps1 Tests/NUnit/ Tests/JUnit/
-          
+
       - store_test_results:
           name: Store test results -> ~/Tests/JUnit
           path: Tests/JUnit
@@ -178,7 +179,7 @@ jobs:
 
   test-unity-2018-4-14f1:
     working_directory: ~/repo
-    
+
     environment:
       SCRIPTS: /root/repo/ci/scripts
       ASSETS_FOLDER: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Assets
@@ -254,7 +255,7 @@ jobs:
 
   test-unity-2019-2-11f1:
     working_directory: ~/repo
-    
+
     environment:
       SCRIPTS: /root/repo/ci/scripts
       ASSETS_FOLDER: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Assets
@@ -320,12 +321,13 @@ jobs:
 
   deploy-cloudsmith:
     working_directory: /root/repo
-    
+
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-deploy-npm:v3
 
     environment:
       SCRIPTS: /root/repo/ci/scripts
+      REPO_FOLDER: /root/repo
       NPM_REGISTRY: https://npm.cloudsmith.io/jillejr/newtonsoft-json-for-unity/
 
     steps:
@@ -340,15 +342,7 @@ jobs:
 
       - run:
           name: Setup Variables
-          command: |
-            env() {
-              echo "export '$1=$2'" >> $BASH_ENV
-              echo "$1='$2'"
-              export "$1=$2"
-            }
-            echo ">>> OBTAINING VERSION FROM $(pwd)/ci/version.json"
-            env VERSION "$($SCRIPTS/get_json_version.sh ./ci/version.json FULL)"
-            echo
+          command: $SCRIPTS/build_setup_variables.sh json false
 
       - run:
           name: NPM Login
@@ -358,27 +352,38 @@ jobs:
             echo "always-auth=true" >> ~/.npmrc
 
       - run:
-          name: NPM Publish
+          name: Deploy
           command: |
             if [ -z "$(npm view jillejr.newtonsoft.json-for-unity@$VERSION versions)" ]
             then
               cd /workspace/package
-              npm publish
+              if [ "${VERSION_AUTO_DEPLOY_DRY_RUN:-}" == "false" ]
+              then
+                npm publish
+              else
+                echo "RUNNING NPM PUBLISH DRY-RUN"
+                npm publish --dry-run
+                echo "RUNNING NPM PUBLISH DRY-RUN"
+            fi
             else
-              echo "Package version $VERSION already existed. Skipping the publish"
+              echo "Package version $VERSION_UPM already existed. Skipping the publish"
             fi
 
   deploy-github:
     working_directory: /root/repo
-    
+
     environment:
       SCRIPTS: /root/repo/ci/scripts
-    
+      REPO_FOLDER: /root/repo
+
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-deploy-github:v4
-    
+
     steps:
       - checkout
+
+      - attach_workspace:
+        at: /workspace
 
       - add_ssh_keys:
           fingerprints:
@@ -394,34 +399,15 @@ jobs:
 
       - run:
           name: Setup Variables
-          command: |
-            env() {
-              echo "export '$1=$2'" >> $BASH_ENV
-              echo "$1='$2'"
-              export "$1=$2"
-            }
-            echo ">>> OBTAINING VERSION FROM $(pwd)/ci/version.json"
-            env VERSION "$($SCRIPTS/get_json_version.sh ./ci/version.json FULL)"
-            env VERSION_RELEASE "$($SCRIPTS/get_json_version.sh ./ci/version.json RELEASE)"
-            env VERSION_JSON_NET "$($SCRIPTS/get_json_version.sh ./ci/version.json JSON_NET)"
-            echo
+          command: $SCRIPTS/build_setup_variables.sh json false
 
       - run:
-          name: Ensure tag exists
-          command: |
-            if git tag --list | egrep -q "^$VERSION$"
-            then
-              echo "Tag $VERSION already existed. Skipping the tagging"
-            else
-              git tag $VERSION -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE"
-              echo "Created tag '$(git tag -l $VERSION -n1)'"
-              git push --tags
-              echo "Successfully pushed tag"
-            fi
+          name: Deploy
+          command: $SCRIPTS/deploy_git.sh /workspace/package
 
   check-deploy-ready:
     working_directory: /root/repo
-    
+
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-deploy-npm:v3
 
@@ -441,57 +427,11 @@ jobs:
 
       - run:
           name: Setup Variables
-          command: |
-            env() {
-              echo "export '$1=$2'" >> $BASH_ENV
-              echo "$1='$2'"
-              export "$1=$2"
-            }
-            echo ">>> OBTAINING VERSION FROM $(pwd)/ci/version.json"
-            env VERSION "$($SCRIPTS/get_json_version.sh ./ci/version.json FULL)"
-            echo
-            
-            echo ">>> SETTING UP NPM"
-            echo "registry='$NPM_REGISTRY' >> ~/.npmrc"
-            echo "registry=$NPM_REGISTRY" >> ~/.npmrc
+          command: $SCRIPTS/build_setup_variables.sh json false
 
       - run:
           name: Check if release is ready for deploy
-          command: |
-            if [ "$(npm search jillejr.newtonsoft.json-for-unity)" == 'No matches found for "jillejr.newtonsoft.json-for-unity"' ]
-            then
-              echo "> Package jillejr.newtonsoft.json-for-unity does not exist on the registry and is available for publishing, all ok!"
-            elif [ -z "$(npm view jillejr.newtonsoft.json-for-unity@$VERSION versions)" ]
-            then
-              echo "> Package jillejr.newtonsoft.json-for-unity version $VERSION does not exist on the registry and is available for publishing, all ok!"
-            else
-              echo
-              echo "[!] Package version $VERSION already existed on $NPM_REGISTRY"
-              echo "[!] Make sure to update the /ci/version.json"
-              exit 1
-            fi
-
-            if git tag --list | egrep -q "^$VERSION$"
-            then
-              echo
-              echo "[!] Tag $VERSION already existed."
-              echo "[!] Make sure to update the /ci/version.json"
-              exit 2
-            else
-              echo "> Tag $VERSION is available for publishing, all ok!"
-            fi
-            
-            if cat CHANGELOG.md | egrep -q "^## $VERSION$"
-            then
-              echo "> Changelog has been updated, all ok!"
-            else
-              echo
-              echo "[!] Changelog in CHANGELOG.md is missing line '## $VERSION'."
-              echo "[!] Make sure to update the CHANGELOG.md"
-              exit 3
-            fi
-
-            echo "Nice work! Happy deploying!"
+          command: $SCRIPTS/check_deploy_ready.sh
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ![Logo](Doc/icons/logo-with-unity.png) Newtonsoft.Json for Unity
 
+[![Latest Version @ OpenUPM](https://img.shields.io/npm/v/jillejr.newtonsoft.json-for-unity?label=openupm&registry_uri=https://package.openupm.com&style=flat-square)](https://openupm.com/packages/jillejr.newtonsoft.json-for-unity/)
 [![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/badges/version/jillejr/newtonsoft-json-for-unity/npm/jillejr.newtonsoft.json-for-unity/latest/x/?render=true&badge_token=gAAAAABeClWC7DvHIyN1IvhxcvGYUIO8CFfs-PsrT973U91i_wmUiuhrzsGZgXqecxQgrEMj4p_-UUUz7XaWjxH3NB8DfA2kkQ%3D%3D)](https://cloudsmith.io/~jillejr/repos/newtonsoft-json-for-unity/packages/detail/npm/jillejr.newtonsoft.json-for-unity/latest/)
 [![CircleCI](https://img.shields.io/circleci/build/gh/jilleJr/Newtonsoft.Json-for-Unity/master?logo=circleci&style=flat-square)](https://circleci.com/gh/jilleJr/Newtonsoft.Json-for-Unity)
 [![Codacy grade](https://img.shields.io/codacy/grade/f91156e7066c484588f4dba263c8cf45?logo=codacy&style=flat-square)](https://www.codacy.com/manual/jilleJr/Newtonsoft.Json-for-Unity?utm_source=github.com&utm_medium=referral&utm_content=jilleJr/Newtonsoft.Json-for-Unity&utm_campaign=Badge_Grade)

--- a/ci/docker_build_images.ps1
+++ b/ci/docker_build_images.ps1
@@ -75,7 +75,7 @@ $Builds = [DockerBuild[]] @(
 
     , [DockerBuild]::new('package-deploy-npm', 'v3')
 
-    , [DockerBuild]::new('package-deploy-github', 'v5')
+    , [DockerBuild]::new('package-deploy-github', 'v6')
 )
 
 $Builds | Start-DockerBuild

--- a/ci/docker_build_images.ps1
+++ b/ci/docker_build_images.ps1
@@ -54,7 +54,7 @@ function Start-DockerBuild  {
                 -t ${ImageName}:latest `
                 @ExtraArgs `
                 $PSScriptRoot
-            
+
             if ($LASTEXITCODE -ne 0) {
                 throw "Failed to build with args $ExtraArgs";
             }
@@ -75,7 +75,7 @@ $Builds = [DockerBuild[]] @(
 
     , [DockerBuild]::new('package-deploy-npm', 'v3')
 
-    , [DockerBuild]::new('package-deploy-github', 'v4')
+    , [DockerBuild]::new('package-deploy-github', 'v5')
 )
 
 $Builds | Start-DockerBuild

--- a/ci/docker_publish_images.ps1
+++ b/ci/docker_publish_images.ps1
@@ -24,5 +24,5 @@ Publish-DockerImage applejag/newtonsoft.json-for-unity.package-builder:latest
 Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-npm:v3
 Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-npm:latest
 
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-github:v4
+Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-github:v5
 Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-github:latest

--- a/ci/docker_publish_images.ps1
+++ b/ci/docker_publish_images.ps1
@@ -1,28 +1,55 @@
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact='Medium')]
+Param (
+    [switch]
+    $Force
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $PSBoundParameters.ContainsKey('Confirm')) {
+    $ConfirmPreference = $PSCmdlet.SessionState.PSVariable.GetValue('ConfirmPreference')
+}
+if (-not $PSBoundParameters.ContainsKey('WhatIf')) {
+    $WhatIfPreference = $PSCmdlet.SessionState.PSVariable.GetValue('WhatIfPreference')
+}
+
 $ErrorActionPreference = "Stop"
 
 function Publish-DockerImage  {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact='Medium')]
     Param (
-        [parameter(ValueFromRemainingArguments = $true)]
-        [string[]]$Passthrough
+        [parameter(ValueFromPipeline=$true)]
+        [string] $Image
     )
 
-    Write-Host ">> Publishing $Passthrough" -BackgroundColor DarkCyan -ForegroundColor White
-    docker push @Passthrough
+    Process {
+        if ($Force -or $PSCmdlet.ShouldProcess($Image)) {
+            Write-Host "`n>> Publishing $Image`n" -ForegroundColor DarkCyan
+            docker push $Image
 
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to publish with args $Passthrough";
+            if (-not $?) {
+                throw "Failed to publish image $Image";
+            }
+        } else {
+            Write-Host "`n>> Skipping pushing image $Image`n" -ForegroundColor DarkGray
+        }
     }
 }
 
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2019.2.11f1
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2018.4.14f1
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-unity-tester:latest
+[string[]] @(
+    , 'applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2019.2.11f1'
+    , 'applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2018.4.14f1'
+    , 'applejag/newtonsoft.json-for-unity.package-unity-tester:latest'
 
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-builder:v2
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-builder:latest
+    , 'applejag/newtonsoft.json-for-unity.package-builder:v2'
+    , 'applejag/newtonsoft.json-for-unity.package-builder:latest'
 
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-npm:v3
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-npm:latest
+    , 'applejag/newtonsoft.json-for-unity.package-deploy-npm:v3'
+    , 'applejag/newtonsoft.json-for-unity.package-deploy-npm:latest'
 
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-github:v5
-Publish-DockerImage applejag/newtonsoft.json-for-unity.package-deploy-github:latest
+    , 'applejag/newtonsoft.json-for-unity.package-deploy-github:v6'
+    , 'applejag/newtonsoft.json-for-unity.package-deploy-github:latest'
+) | Publish-DockerImage
+
+Write-Host "`n>> Done! `n" -ForegroundColor DarkGreen

--- a/ci/package-deploy-github.Dockerfile
+++ b/ci/package-deploy-github.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.1-slim
+FROM ubuntu:18.04
 
 # Should correspond to the image tag
 ARG IMAGE_VERSION
@@ -6,11 +6,11 @@ ENV IMAGE_VERSION=${IMAGE_VERSION}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        jq=1.5+dfsg-2+b1 \
-        git=1:2.20.1-2 \
-        ssh=1:7.9p1-10+deb10u1 \
-        gpg=2.2.12-1+deb10u1 \
-        gpg-agent=2.2.12-1+deb10u1 \
+        jq=1.5+dfsg-2 \
+        git=1:2.17.1-1ubuntu0.7 \
+        ssh=1:7.6p1-4ubuntu0.3 \
+        gpg=2.2.4-1ubuntu1.2 \
+        gpg-agent=2.2.4-1ubuntu1.2 \
     # Cleanup cache
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/ci/package-deploy-github.Dockerfile
+++ b/ci/package-deploy-github.Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         ssh=1:7.6p1-4ubuntu0.3 \
         gpg=2.2.4-1ubuntu1.2 \
         gpg-agent=2.2.4-1ubuntu1.2 \
+        ca-certificates=20180409 \
     # Cleanup cache
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/ci/scripts/build_setup_variables.sh
+++ b/ci/scripts/build_setup_variables.sh
@@ -26,7 +26,7 @@ if [ "$VAR_SOURCE" == "xml" ]; then
     env VERSION_SUFFIX "$(xml VersionSuffix)"
     env VERSION_JSON_NET "$(xml VersionPrefix)"
     env VERSION_ASSEMBLY "$(xml AssemblyVersion)"
-    env VERSION_AUTO_DEPLOY_DRY_RUN 'false'
+    env VERSION_AUTO_DEPLOY_LIVE_RUN 'false'
     echo
 elif [ "$VAR_SOURCE" == "json" ]; then
     json() {
@@ -39,7 +39,7 @@ elif [ "$VAR_SOURCE" == "json" ]; then
     env VERSION_JSON_NET "$(json JSON_NET)"
     env VERSION_ASSEMBLY "$(json ASSEMBLY)"
     env VERSION_RELEASE "$(json RELEASE)"
-    env VERSION_AUTO_DEPLOY_DRY_RUN "$(json AUTO_DEPLOY_DRY_RUN)"
+    env VERSION_AUTO_DEPLOY_LIVE_RUN "$(json AUTO_DEPLOY_LIVE_RUN)"
     echo
 else
     echo "Invalid argument: '${VAR_SOURCE}'" >&2

--- a/ci/scripts/build_setup_variables.sh
+++ b/ci/scripts/build_setup_variables.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Set error flags
+set -o nounset
+set -o errexit
+set -o pipefail
+
+VAR_SOURCE="${1:-json}"
+UPDATE_PACKAGE_JSON="${2:-false}"
+
+env() {
+    echo "export '$1=$2'" >> $BASH_ENV
+    echo "$1='$2'"
+    export "$1=$2"
+}
+
+if [ "$VAR_SOURCE" == "xml" ]; then
+    xml() {
+        xmlstarlet sel -t -v "/Project/PropertyGroup/$1" -n Src/Newtonsoft.Json/Newtonsoft.Json.csproj | head -n 1
+    }
+
+    echo ">>> OBTAINING VERSION FROM $(pwd)/Src/Newtonsoft.Json/Newtonsoft.Json.csproj"
+    env VERSION "$(xml VersionPrefix)"
+    env VERSION_SUFFIX "$(xml VersionSuffix)"
+    env VERSION_JSON_NET "$(xml VersionPrefix)"
+    env VERSION_ASSEMBLY "$(xml AssemblyVersion)"
+    echo
+elif [ "$VAR_SOURCE" == "json" ]; then
+    json() {
+        $SCRIPTS/get_json_version.sh ./ci/version.json "$1"
+    }
+
+    echo ">>> OBTAINING VERSION FROM $(pwd)/ci/version.json"
+    env VERSION "$(json FULL)"
+    env VERSION_SUFFIX "$(json SUFFIX)"
+    env VERSION_JSON_NET "$(json JSON_NET)"
+    env VERSION_ASSEMBLY "$(json ASSEMBLY)"
+    echo
+else
+    echo "Invalid argument: '${VAR_SOURCE}'" >&2
+    echo "Valid values: 'json', 'xml'" >&2
+    exit 1
+fi
+
+if [ "$UPDATE_PACKAGE_JSON" == 'true' ]; then
+    echo ">>> UPDATING VERSION IN $(pwd)/Src/Newtonsoft.Json-for-Unity/package.json"
+    echo "BEFORE:"
+    echo ".version=$(jq ".version" Src/Newtonsoft.Json-for-Unity/package.json)"
+    echo ".displayName=$(jq ".displayName" Src/Newtonsoft.Json-for-Unity/package.json)"
+    echo "$(jq ".version=\"$VERSION\" | .displayName=\"Json.NET $VERSION_JSON_NET for Unity\"" Src/Newtonsoft.Json-for-Unity/package.json)" > Src/Newtonsoft.Json-for-Unity/package.json
+    echo "AFTER:"
+    echo ".version=$(jq ".version" Src/Newtonsoft.Json-for-Unity/package.json)"
+    echo ".displayName=$(jq ".displayName" Src/Newtonsoft.Json-for-Unity/package.json)"
+fi

--- a/ci/scripts/build_setup_variables.sh
+++ b/ci/scripts/build_setup_variables.sh
@@ -24,6 +24,7 @@ if [ "$VAR_SOURCE" == "xml" ]; then
     env VERSION_SUFFIX "$(xml VersionSuffix)"
     env VERSION_JSON_NET "$(xml VersionPrefix)"
     env VERSION_ASSEMBLY "$(xml AssemblyVersion)"
+    env VERSION_AUTO_DEPLOY_DRY_RUN 'false'
     echo
 elif [ "$VAR_SOURCE" == "json" ]; then
     json() {
@@ -35,6 +36,7 @@ elif [ "$VAR_SOURCE" == "json" ]; then
     env VERSION_SUFFIX "$(json SUFFIX)"
     env VERSION_JSON_NET "$(json JSON_NET)"
     env VERSION_ASSEMBLY "$(json ASSEMBLY)"
+    env VERSION_AUTO_DEPLOY_DRY_RUN "$(json AUTO_DEPLOY_DRY_RUN)"
     echo
 else
     echo "Invalid argument: '${VAR_SOURCE}'" >&2

--- a/ci/scripts/build_setup_variables.sh
+++ b/ci/scripts/build_setup_variables.sh
@@ -38,6 +38,7 @@ elif [ "$VAR_SOURCE" == "json" ]; then
     env VERSION_SUFFIX "$(json SUFFIX)"
     env VERSION_JSON_NET "$(json JSON_NET)"
     env VERSION_ASSEMBLY "$(json ASSEMBLY)"
+    env VERSION_RELEASE "$(json RELEASE)"
     env VERSION_AUTO_DEPLOY_DRY_RUN "$(json AUTO_DEPLOY_DRY_RUN)"
     echo
 else

--- a/ci/scripts/build_setup_variables.sh
+++ b/ci/scripts/build_setup_variables.sh
@@ -7,7 +7,8 @@ set -o pipefail
 
 VAR_SOURCE="${1:-json}"
 UPDATE_PACKAGE_JSON="${2:-false}"
-FILE_SOURCE="${3:-"$(pwd)/ci/version.json"}"
+SOURCE_PATH="${3:-"$(pwd)/ci/version.json"}"
+PACKAGE_JSON_PATH="${4:-"$(pwd)/Src/Newtonsoft.Json-for-Unity/package.json"}"
 
 env() {
     echo "export '$1=$2'" >> $BASH_ENV
@@ -20,7 +21,7 @@ if [ "$VAR_SOURCE" == "xml" ]; then
         xmlstarlet sel -t -v "/Project/PropertyGroup/$1" -n Src/Newtonsoft.Json/Newtonsoft.Json.csproj | head -n 1
     }
 
-    echo ">>> OBTAINING VERSION FROM $FILE_SOURCE"
+    echo ">>> OBTAINING VERSION FROM $SOURCE_PATH"
     env VERSION "$(xml VersionPrefix)"
     env VERSION_SUFFIX "$(xml VersionSuffix)"
     env VERSION_JSON_NET "$(xml VersionPrefix)"
@@ -32,7 +33,7 @@ elif [ "$VAR_SOURCE" == "json" ]; then
         $SCRIPTS/get_json_version.sh ./ci/version.json "$1"
     }
 
-    echo ">>> OBTAINING VERSION FROM $FILE_SOURCE"
+    echo ">>> OBTAINING VERSION FROM $SOURCE_PATH"
     env VERSION "$(json FULL)"
     env VERSION_SUFFIX "$(json SUFFIX)"
     env VERSION_JSON_NET "$(json JSON_NET)"
@@ -46,12 +47,12 @@ else
 fi
 
 if [ "$UPDATE_PACKAGE_JSON" == 'true' ]; then
-    echo ">>> UPDATING VERSION IN $(pwd)/Src/Newtonsoft.Json-for-Unity/package.json"
+    echo ">>> UPDATING VERSION IN $PACKAGE_JSON_PATH"
     echo "BEFORE:"
-    echo ".version=$(jq ".version" Src/Newtonsoft.Json-for-Unity/package.json)"
-    echo ".displayName=$(jq ".displayName" Src/Newtonsoft.Json-for-Unity/package.json)"
-    echo "$(jq ".version=\"$VERSION\" | .displayName=\"Json.NET $VERSION_JSON_NET for Unity\"" Src/Newtonsoft.Json-for-Unity/package.json)" > Src/Newtonsoft.Json-for-Unity/package.json
+    echo ".version=$(jq ".version" $PACKAGE_JSON_PATH)"
+    echo ".displayName=$(jq ".displayName" $PACKAGE_JSON_PATH)"
+    echo "$(jq ".version=\"$VERSION\" | .displayName=\"Json.NET $VERSION_JSON_NET for Unity\"" $PACKAGE_JSON_PATH)" > $PACKAGE_JSON_PATH
     echo "AFTER:"
-    echo ".version=$(jq ".version" Src/Newtonsoft.Json-for-Unity/package.json)"
-    echo ".displayName=$(jq ".displayName" Src/Newtonsoft.Json-for-Unity/package.json)"
+    echo ".version=$(jq ".version" $PACKAGE_JSON_PATH)"
+    echo ".displayName=$(jq ".displayName" $PACKAGE_JSON_PATH)"
 fi

--- a/ci/scripts/build_setup_variables.sh
+++ b/ci/scripts/build_setup_variables.sh
@@ -7,6 +7,7 @@ set -o pipefail
 
 VAR_SOURCE="${1:-json}"
 UPDATE_PACKAGE_JSON="${2:-false}"
+FILE_SOURCE="${3:-"$(pwd)/ci/version.json"}"
 
 env() {
     echo "export '$1=$2'" >> $BASH_ENV
@@ -19,7 +20,7 @@ if [ "$VAR_SOURCE" == "xml" ]; then
         xmlstarlet sel -t -v "/Project/PropertyGroup/$1" -n Src/Newtonsoft.Json/Newtonsoft.Json.csproj | head -n 1
     }
 
-    echo ">>> OBTAINING VERSION FROM $(pwd)/Src/Newtonsoft.Json/Newtonsoft.Json.csproj"
+    echo ">>> OBTAINING VERSION FROM $FILE_SOURCE"
     env VERSION "$(xml VersionPrefix)"
     env VERSION_SUFFIX "$(xml VersionSuffix)"
     env VERSION_JSON_NET "$(xml VersionPrefix)"
@@ -31,7 +32,7 @@ elif [ "$VAR_SOURCE" == "json" ]; then
         $SCRIPTS/get_json_version.sh ./ci/version.json "$1"
     }
 
-    echo ">>> OBTAINING VERSION FROM $(pwd)/ci/version.json"
+    echo ">>> OBTAINING VERSION FROM $FILE_SOURCE"
     env VERSION "$(json FULL)"
     env VERSION_SUFFIX "$(json SUFFIX)"
     env VERSION_JSON_NET "$(json JSON_NET)"

--- a/ci/scripts/check_deploy_ready.sh
+++ b/ci/scripts/check_deploy_ready.sh
@@ -5,8 +5,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-: ${VERSION_UPM:?"Need the version to be checked"}
-: ${VERSION_UPM_NO_SUFFIX:?"Need the version of Newtonsoft.Json.UnityConverters (without suffix) to be checked"}
+: ${VERSION:?"Need the version to be checked"}
 
 OK=1
 

--- a/ci/scripts/check_deploy_ready.sh
+++ b/ci/scripts/check_deploy_ready.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Set error flags
+set -o nounset
+set -o errexit
+set -o pipefail
+
+: ${VERSION_UPM:?"Need the version to be checked"}
+: ${VERSION_UPM_NO_SUFFIX:?"Need the version of Newtonsoft.Json.UnityConverters (without suffix) to be checked"}
+
+OK=1
+
+echo
+
+if git show-ref --verify --quiet refs/remotes/origin/upm
+then
+    echo "> Branch 'upm' exists, all ok!"
+else
+    echo "[!] Missing branch 'upm'."
+    echo "[!] Make sure to create that branch in advance"
+    echo "[!] Branches found:"
+    git show-ref
+    OK=0
+fi
+
+echo
+
+if egrep -q "^## ${VERSION//\./\\.}$" CHANGELOG.md
+then
+    echo "> Changelog has been updated, all ok!"
+else
+    echo "[!] Changelog in CHANGELOG.md is missing line '## $VERSION'."
+    echo "[!] Make sure to update the CHANGELOG.md"
+    OK=0
+fi
+
+echo
+
+for ENV_VAR in NPM_AUTH_TOKEN GITHUB_USER_EMAIL GITHUB_USER_NAME GITHUB_GPG_ID GITHUB_GPG_SEC_B64
+do
+    if [ -z "${!ENV_VAR}" ]
+    then
+        echo "[!] Missing environment variable \$$ENV_VAR."
+        OK=0
+    else
+        echo "> Environment variable \$$ENV_VAR is set, all ok!"
+    fi
+
+    echo
+done
+
+echo
+
+if [ $OK != 1 ]
+then
+    echo "At least one check failed. Aborting!"
+    exit 1
+fi
+
+echo "Nice work! Happy deploying!"

--- a/ci/scripts/deploy_git.sh
+++ b/ci/scripts/deploy_git.sh
@@ -12,62 +12,87 @@ PACKAGE_FOLDER="${1:-${PACKAGE_FOLDER:?'Package folder required'}}"
 : ${VERSION_RELEASE:?}
 : ${REPO_FOLDER:?}
 
-if git tag --list | egrep -q "^$VERSION$"
+TAG_UPM="upm/$VERSION"
+TAG_MASTER="$VERSION"
+
+tag_and_push() {
+    local tagName="$1"
+    local tagMessage="$2"
+
+    git tag $tagName -m "$tagMessage"
+
+    echo "Created tag: '$(git tag -l $tagName -n1))'"
+
+    if [ "${VERSION_AUTO_DEPLOY_DRY_RUN:-}" == "false" ]
+    then
+        git push --follow-tags
+    else
+        echo "RUNNING GIT PUSH DRY-RUN"
+        git push --follow-tags --dry-run
+        echo "RUNNING GIT PUSH DRY-RUN"
+    fi
+    echo
+    echo "Successfully pushed"
+}
+
+#-------------------------------------------------------------------------------
+
+if git tag --list | egrep -q "^$TAG_MASTER$"
 then
-    echo "Tag $VERSION already existed. Skipping the deployment"
-    exit 0
+    echo "Tag $TAG_MASTER already existed. Skipping the tagging on master branch"
+else
+    tag_and_push $TAG_MASTER "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
+
+Created by CircleCI job
+Build #$CIRCLE_BUILD_NUM
+$CIRCLE_BUILD_URL"
 fi
 
-echo ">> Checking out upm branch"
-git checkout upm --force
-echo
+#-------------------------------------------------------------------------------
 
-echo ">> Replacing package"
-shopt -s dotglob
-GLOBIGNORE='.git' git rm \* -rf --ignore-unmatch
-git clean -dfx
-mv $PACKAGE_FOLDER/* $REPO_FOLDER/.
-shopt -u dotglob
-git add .
-echo
-
-echo ">> Status"
-git status --short
-STATUS="$(git status --short)"
-echo
-
-if [ -z "$STATUS" ]
+if git tag --list | egrep -q "^$TAG_UPM$"
 then
-    echo "No changes to package in UPM branch. Will not create a new commit."
+    echo "Tag $TAG_UPM already existed. Skipping the deployment to upm branch"
 else
-    git commit -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
+
+    echo ">> Checking out upm branch"
+    git checkout upm --force
+    echo
+
+    echo ">> Replacing package"
+    shopt -s dotglob
+    GLOBIGNORE='.git' git rm \* -rf --ignore-unmatch
+    git clean -dfx
+    mv $PACKAGE_FOLDER/* $REPO_FOLDER/.
+    shopt -u dotglob
+    git add .
+    echo
+
+    echo ">> Status"
+    git status --short
+    STATUS="$(git status --short)"
+    echo
+
+    if [ -z "$STATUS" ]
+    then
+        echo "No changes to package in UPM branch. Will not create a new commit."
+    else
+        git commit -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
 
 Based on commit $CIRCLE_SHA1
 
 Created by CircleCI job
 Build #$CIRCLE_BUILD_NUM
 $CIRCLE_BUILD_URL"
-    echo "Created commit '$(git log -n1 --format="%s")'"
-fi
-echo
+        echo "Created commit '$(git log -n1 --format="%s")'"
+    fi
+    echo
 
-git tag $VERSION -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
+    tag_and_push $TAG_UPM "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
 
 Based on commit $CIRCLE_SHA1
 
 Created by CircleCI job
 Build #$CIRCLE_BUILD_NUM
 $CIRCLE_BUILD_URL"
-
-echo "Created tag '$(git tag -l $VERSION -n1)'"
-
-if [ "${VERSION_AUTO_DEPLOY_DRY_RUN:-}" == "false" ]
-then
-    git push --follow-tags
-else
-    echo "RUNNING GIT PUSH DRY-RUN"
-    git push --follow-tags --dry-run
-    echo "RUNNING GIT PUSH DRY-RUN"
 fi
-echo
-echo "Successfully pushed"

--- a/ci/scripts/deploy_git.sh
+++ b/ci/scripts/deploy_git.sh
@@ -12,8 +12,7 @@ PACKAGE_FOLDER="${1:-${PACKAGE_FOLDER:?'Package folder required'}}"
 : ${VERSION_RELEASE:?}
 : ${REPO_FOLDER:?}
 
-TAG_UPM="upm/$VERSION"
-TAG_MASTER="$VERSION"
+TAG_UPM="$VERSION"
 
 tag_and_push() {
     local tagName="$1"
@@ -34,19 +33,6 @@ tag_and_push() {
     echo
     echo "Successfully pushed"
 }
-
-#-------------------------------------------------------------------------------
-
-if git tag --list | egrep -q "^$TAG_MASTER$"
-then
-    echo "Tag $TAG_MASTER already existed. Skipping the tagging on master branch"
-else
-    tag_and_push $TAG_MASTER "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
-
-Created by CircleCI job
-Build #$CIRCLE_BUILD_NUM
-$CIRCLE_BUILD_URL"
-fi
 
 #-------------------------------------------------------------------------------
 

--- a/ci/scripts/deploy_git.sh
+++ b/ci/scripts/deploy_git.sh
@@ -7,14 +7,14 @@ set -o pipefail
 
 PACKAGE_FOLDER="${1:-${PACKAGE_FOLDER:?'Package folder required'}}"
 
-: ${VERSION_UPM:?}
-: ${VERSION_UPM_NO_SUFFIX:?}
-: ${VERSION_SUFFIX:?}
+: ${VERSION:?}
+: ${VERSION_JSON_NET:?}
+: ${VERSION_RELEASE:?}
 : ${REPO_FOLDER:?}
 
-if git tag --list | egrep -q "^$VERSION_UPM$"
+if git tag --list | egrep -q "^$VERSION$"
 then
-    echo "Tag $VERSION_UPM already existed. Skipping the deployment"
+    echo "Tag $VERSION already existed. Skipping the deployment"
     exit 0
 fi
 

--- a/ci/scripts/deploy_git.sh
+++ b/ci/scripts/deploy_git.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Set error flags
+set -o nounset
+set -o errexit
+set -o pipefail
+
+PACKAGE_FOLDER="${1:-${PACKAGE_FOLDER:?'Package folder required'}}"
+
+: ${VERSION_UPM:?}
+: ${VERSION_UPM_NO_SUFFIX:?}
+: ${VERSION_SUFFIX:?}
+: ${REPO_FOLDER:?}
+
+if git tag --list | egrep -q "^$VERSION_UPM$"
+then
+    echo "Tag $VERSION_UPM already existed. Skipping the deployment"
+    exit 0
+fi
+
+echo ">> Checking out upm branch"
+git checkout upm --force
+echo
+
+echo ">> Replacing package"
+shopt -s dotglob
+GLOBIGNORE='.git' git rm \* -rf --ignore-unmatch
+git clean -dfx
+mv $PACKAGE_FOLDER/* $REPO_FOLDER/.
+shopt -u dotglob
+git add .
+echo
+
+echo ">> Status"
+git status --short
+STATUS="$(git status --short)"
+echo
+
+if [ -z "$STATUS" ]
+then
+    echo "No changes to package in UPM branch. Will not create a new commit."
+else
+    git commit -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
+
+Created by CircleCI job
+Build #$CIRCLE_BUILD_NUM
+$CIRCLE_BUILD_URL"
+    echo "Created commit '$(git log -n1 --format="%s")'"
+fi
+echo
+
+git tag $VERSION -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
+
+Created by CircleCI job
+Build #$CIRCLE_BUILD_NUM
+$CIRCLE_BUILD_URL"
+
+echo "Created tag '$(git tag -l $VERSION -n1)'"
+
+if [ "${VERSION_AUTO_DEPLOY_DRY_RUN:-}" == "false" ]
+then
+    git push --follow-tags
+else
+    echo "RUNNING GIT PUSH DRY-RUN"
+    git push --follow-tags --dry-run
+    echo "RUNNING GIT PUSH DRY-RUN"
+fi
+echo
+echo "Successfully pushed"

--- a/ci/scripts/deploy_git.sh
+++ b/ci/scripts/deploy_git.sh
@@ -22,7 +22,7 @@ tag_and_push() {
 
     echo "Created tag: '$(git tag -l $tagName -n1))'"
 
-    if [ "${VERSION_AUTO_DEPLOY_DRY_RUN:-}" == "false" ]
+    if [ "${VERSION_AUTO_DEPLOY_LIVE_RUN:-}" == "true" ]
     then
         git push --follow-tags
     else

--- a/ci/scripts/deploy_git.sh
+++ b/ci/scripts/deploy_git.sh
@@ -42,6 +42,8 @@ then
 else
     git commit -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
 
+Based on commit $CIRCLE_SHA1
+
 Created by CircleCI job
 Build #$CIRCLE_BUILD_NUM
 $CIRCLE_BUILD_URL"
@@ -50,6 +52,8 @@ fi
 echo
 
 git tag $VERSION -m "Json.NET $VERSION_JSON_NET, release $VERSION_RELEASE
+
+Based on commit $CIRCLE_SHA1
 
 Created by CircleCI job
 Build #$CIRCLE_BUILD_NUM

--- a/ci/scripts/get_json_version.sh
+++ b/ci/scripts/get_json_version.sh
@@ -62,12 +62,12 @@ SUFFIX)
 RELEASE)
     jq2 -er '.Release // 0' "$jsonFile"
     ;;
-AUTO_DEPLOY_DRY_RUN)
-    jq2 -r '.AutoDeployDryRun' "$jsonFile"
+AUTO_DEPLOY_LIVE_RUN)
+    jq2 -r '.AutoDeployLiveRun' "$jsonFile"
     ;;
 *)
     error "Error: Unknown output type '$output'
-    Possible values: FULL, JSON_NET, ASSEMBLY, SUFFIX, RELEASE, AUTO_DEPLOY_DRY_RUN"
+    Possible values: FULL, JSON_NET, ASSEMBLY, SUFFIX, RELEASE, AUTO_DEPLOY_LIVE_RUN"
     exit 3
     ;;
 esac

--- a/ci/scripts/get_json_version.sh
+++ b/ci/scripts/get_json_version.sh
@@ -49,7 +49,7 @@ ASSEMBLY)
     jq2 -er '(.Major // 0|tostring) + ".0.0.0"' "$jsonFile"
     ;;
 SUFFIX)
-    release="$(jq2 -er '.Release // empty' "$jsonFile")"
+    release="$(jq -er '.Release // empty' "$jsonFile")"
 
     if [ -z "$release" ]
     then

--- a/ci/scripts/get_json_version.sh
+++ b/ci/scripts/get_json_version.sh
@@ -50,7 +50,7 @@ ASSEMBLY)
     ;;
 SUFFIX)
     release="$(jq2 -er '.Release // empty' "$jsonFile")"
-    
+
     if [ -z "$release" ]
     then
         # No suffix
@@ -62,9 +62,12 @@ SUFFIX)
 RELEASE)
     jq2 -er '.Release // 0' "$jsonFile"
     ;;
+AUTO_DEPLOY_DRY_RUN)
+    jq2 -r '.AutoDeployDryRun' "$jsonFile"
+    ;;
 *)
     error "Error: Unknown output type '$output'
-    Possible values: FULL, JSON_NET, ASSEMBLY, SUFFIX, RELEASE"
+    Possible values: FULL, JSON_NET, ASSEMBLY, SUFFIX, RELEASE, AUTO_DEPLOY_DRY_RUN"
     exit 3
     ;;
 esac

--- a/ci/version.json
+++ b/ci/version.json
@@ -5,5 +5,5 @@
 
   "Release": 1,
 
-  "AutoDeployDryRun": true
+  "AutoDeployLiveRun": false
 }

--- a/ci/version.json
+++ b/ci/version.json
@@ -3,5 +3,7 @@
   "Minor": 0,
   "Patch": 3,
 
-  "Release": 1
+  "Release": 1,
+
+  "AutoDeployDryRun": true
 }


### PR DESCRIPTION
Adding changes to the main README is too tedious with these automatic deployment scripts. They are in the way instead of helping.

They could possibly deploy automatically, but better if they do nothing if it's already exist instead of failing.