### PR TITLE
backport/11.0.2: Markdown emphasis using * instead of _ (#94)

### DIFF
--- a/.github/ISSUE_TEMPLATE/.remarkrc
+++ b/.github/ISSUE_TEMPLATE/.remarkrc
@@ -1,7 +1,6 @@
 {
     "plugins": [
         "preset-lint-markdown-style-guide",
-        ["lint-emphasis-marker", "*"],
         ["lint-list-item-indent", "space"],
         ["lint-ordered-list-marker-value", "ordered"],
         ["lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"],

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,7 +1,6 @@
 {
     "plugins": [
         "preset-lint-markdown-style-guide",
-        ["lint-emphasis-marker", "*"],
         ["lint-list-item-indent", "space"],
         ["lint-ordered-list-marker-value", "ordered"],
         ["lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 
     - 🔄 Change: Better versioning format. For more info see
       [the wiki page][wiki-versioning]. Changes are based of off `12.0.1`
-      version _(in previous format)._
+      version *(in previous format).*
 
     - 🐛 Fix: Building on standalone causes plugin collision ([#3][#3])
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-<sup>_Yes, this is the same content as the [How to contribute][wiki-contributing] page on the wiki._</sup>
+<sup>*Yes, this is the same content as the [How to contribute][wiki-contributing] page on the wiki.*</sup>
 
 # How to contribute
 Any help given on this project is massively appreciated! ❤

--- a/Src/Newtonsoft.Json-for-Unity.Tests/README.md
+++ b/Src/Newtonsoft.Json-for-Unity.Tests/README.md
@@ -62,7 +62,7 @@ $Unity = "C:\Program Files\Unity\Hub\Editor\2019.2.11f1\Editor\Unity.exe"
 
 `testPlatform` parameter values:
 
-- `editmode` _(default)_
+- `editmode` *(default)*
 - `playmode`
 - `StandaloneWindows`
 - `StandaloneWindows64`


### PR DESCRIPTION
Backports the following commits to backport/11.0.2:
 - Markdown emphasis using * instead of _ (#94)