### PR TITLE
Simplify CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,19 +43,19 @@ commands:
                 command: $SCRIPTS/build_setup_variables.sh json <<parameters.update-package-json>> $REPO_FOLDER/ci/version.json
 
 executors:
-  unity-2018.4.14f1: &unity-2018.4.14f1-executor
+  unity-2018-4-14f1: &unity-2018-4-14f1-executor
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2018.4.14f1
     environment:
       UNITY_LICENSE_CONTENT_B64: $UNITY_2018_4_14F1_LICENSE_CONTENT_B64
 
-  unity-2019.2.11f1:
+  unity-2019-2-11f1:
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2019.2.11f1
     environment:
       UNITY_LICENSE_CONTENT_B64: $UNITY_2019_2_11F1_LICENSE_CONTENT_B64
 
-  unity-2020.1.0b6:
+  unity-2020-1-0b6:
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2020.1.0b6-linux-il2cpp
     environment:
@@ -246,7 +246,7 @@ jobs:
 
       - when:
           condition:
-            equal: [ *unity-2018.4.14f1-executor, <<parameters.unity-version>> ]
+            equal: [ *unity-2018-4-14f1-executor, <<parameters.unity-version>> ]
           steps:
             - run:
                 name: Downgrade Unity project to 2018.x
@@ -388,7 +388,7 @@ workflows:
       - test-unity:
           matrix:
             parameters:
-              unity-version: [ 2018.4.14f1, 2019.2.11f1, 2020.1.0b6 ]
+              unity-version: [ 2018-4-14f1, 2019-2-11f1, 2020-1-0b6 ]
           requires:
             - build-package
   check-deploy-ready:
@@ -409,7 +409,7 @@ workflows:
       - test-unity:
           matrix:
             parameters:
-              unity-version: [ 2018.4.14f1, 2019.2.11f1, 2020.1.0b6 ]
+              unity-version: [ 2018-4-14f1, 2019-2-11f1, 2020-1-0b6 ]
           requires:
             - build-package
       - check-deploy-ready:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
       - run:
           name: Setup Unity license
           command: |
-            UNITY_LICENSE_CONTENT_B64="${$UNITY_LICENSE_CONTENT_B64_ENV}" $SCRIPTS/unity_login.sh
+            UNITY_LICENSE_CONTENT_B64="${!UNITY_LICENSE_CONTENT_B64_ENV}" $SCRIPTS/unity_login.sh
 
       - attach_workspace:
           at: /workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
       unity-version:
         type: executor
 
-    executor: unity-<<parameters.unity-version>>
+    executor: <<parameters.unity-version>>
     working_directory: ~/repo
 
     environment:
@@ -388,7 +388,7 @@ workflows:
       - test-unity:
           matrix:
             parameters:
-              unity-version: [ 2018-4-14f1, 2019-2-11f1, 2020-1-0b6 ]
+              unity-version: [ unity-2018-4-14f1, unity-2019-2-11f1, unity-2020-1-0b6 ]
           requires:
             - build-package
   check-deploy-ready:
@@ -409,7 +409,7 @@ workflows:
       - test-unity:
           matrix:
             parameters:
-              unity-version: [ 2018-4-14f1, 2019-2-11f1, 2020-1-0b6 ]
+              unity-version: [ unity-2018-4-14f1, unity-2019-2-11f1, unity-2020-1-0b6 ]
           requires:
             - build-package
       - check-deploy-ready:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ commands:
             - run:
                 name: Setup Variables
                 command: $SCRIPTS/build_setup_variables.sh json <<parameters.update-package-json>> $REPO_FOLDER/ci/version.json
+      - run:
+          name: Store Unity version to file
+          command: echo "$UNITY_VERSION" > /unity-version.txt
 
 executors:
   unity-2018-4-14f1: &unity-2018-4-14f1-executor
@@ -227,11 +230,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - test-unity-upm-manifest-{{ .Environment.UNITY_VERSION }}
+            - test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity/Packages/manifest.json" }}
+            - test-unity-upm-manifest
 
       - restore_cache:
           keys:
-            - test-unity-upm-global-{{ .Environment.UNITY_VERSION }}
+            - test-unity-upm-global-{{ checksum "/unity-version.txt" }}
+            - test-unity-upm-global
 
       - run:
           name: Setup Unity license
@@ -275,12 +280,12 @@ jobs:
           path: ~/tests/junit
 
       - save_cache:
-          key: test-unity-upm-manifest-{{ .Environment.UNITY_VERSION }}
+          key: test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity/Packages/manifest.json" }}
           paths:
             - /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Library/PackageCache
 
       - save_cache:
-          key: test-unity-upm-global-{{ .Environment.UNITY_VERSION }}
+          key: test-unity-upm-global-{{ checksum "/unity-version.txt" }}
           paths:
             - /root/.config/unity3d/cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,27 @@ preset-filter-check: &WORKFLOW_CHECK_DEPLOY_READY_FILTER
 orbs:
   win: circleci/windows@2.4.0
 
+commands:
+  checkout-and-setup:
+    parameters:
+      setup-variables:
+        type: boolean
+        default: false
+      update-package-json:
+        type: boolean
+        default: false
+    steps:
+      - checkout
+      - run:
+          name: Enable permissions on scripts
+          command: chmod +x $SCRIPTS/**.sh -v
+      - when:
+          condition: <<parameters.setup-variables>>
+          steps:
+            - run:
+                name: Setup Variables
+                command: $SCRIPTS/build_setup_variables.sh json <<parameters.update-package-json>> $REPO_FOLDER/ci/version.json
+
 jobs:
   build-package:
     working_directory: ~/repo
@@ -38,22 +59,14 @@ jobs:
 
     steps:
       # Checkout repo -> ~/repo
-      - checkout
+      - checkout-and-setup:
+          setup-variables: true
+          update-package-json: true
 
       - restore_cache:
           keys:
             - build-package-nuget
 
-      - run:
-          name: Enable permissions on scripts
-          command: chmod +x $SCRIPTS/**.sh -v
-
-      - run:
-          name: Setup variables
-          command: |
-            $SCRIPTS/build_setup_variables.sh json true \
-              $REPO_FOLDER/ci/version.json \
-              $REPO_FOLDER/Src/Newtonsoft.Json-for-Unity/package.json
       - run:
           name: NuGet restore
           command: |
@@ -196,7 +209,7 @@ jobs:
 
     steps:
       # Checkout repo -> ~/repo
-      - checkout
+      - checkout-and-setup
 
       - restore_cache:
           keys:
@@ -205,10 +218,6 @@ jobs:
       - restore_cache:
           keys:
             - test-unity-upm-global-<<parameters.unity-version>>
-
-      - run:
-          name: Enable permissions on scripts
-          command: chmod +x $SCRIPTS/**.sh -v
 
       - run:
           name: Setup Unity license
@@ -272,18 +281,11 @@ jobs:
       NPM_REGISTRY: https://npm.cloudsmith.io/jillejr/newtonsoft-json-for-unity/
 
     steps:
-      - checkout
+      - checkout-and-setup:
+          setup-variables: true
 
       - attach_workspace:
           at: /workspace
-
-      - run:
-          name: Enable permissions on scripts
-          command: chmod +x $SCRIPTS/**.sh -v
-
-      - run:
-          name: Setup Variables
-          command: $SCRIPTS/build_setup_variables.sh json false $REPO_FOLDER/ci/version.json
 
       - run:
           name: NPM Login
@@ -321,7 +323,8 @@ jobs:
       - image: applejag/newtonsoft.json-for-unity.package-deploy-github:v6
 
     steps:
-      - checkout
+      - checkout-and-setup:
+          setup-variables: true
 
       - attach_workspace:
           at: /workspace
@@ -331,16 +334,8 @@ jobs:
             - "82:cf:73:91:b8:06:21:84:9e:79:98:57:11:03:5f:db"
 
       - run:
-          name: Enable permissions on scripts
-          command: chmod +x $SCRIPTS/**.sh -v
-
-      - run:
           name: Git Login
           command: $SCRIPTS/git_login.sh
-
-      - run:
-          name: Setup Variables
-          command: $SCRIPTS/build_setup_variables.sh json false $REPO_FOLDER/ci/version.json
 
       - run:
           name: Deploy
@@ -357,18 +352,11 @@ jobs:
       NPM_REGISTRY: https://npm.cloudsmith.io/jillejr/newtonsoft-json-for-unity/
 
     steps:
-      - checkout
+      - checkout-and-setup:
+          setup-variables: true
 
       - attach_workspace:
           at: /workspace
-
-      - run:
-          name: Enable permissions on scripts
-          command: chmod +x $SCRIPTS/**.sh -v
-
-      - run:
-          name: Setup Variables
-          command: $SCRIPTS/build_setup_variables.sh json false $REPO_FOLDER/ci/version.json
 
       - run:
           name: Check if release is ready for deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,19 +47,19 @@ executors:
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2018.4.14f1
     environment:
-      UNITY_LICENSE_CONTENT_B64: $UNITY_2018_4_14F1_LICENSE_CONTENT_B64
+      UNITY_LICENSE_CONTENT_B64_ENV: UNITY_2018_4_14F1_LICENSE_CONTENT_B64
 
   unity-2019-2-11f1:
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2019.2.11f1
     environment:
-      UNITY_LICENSE_CONTENT_B64: $UNITY_2019_2_11F1_LICENSE_CONTENT_B64
+      UNITY_LICENSE_CONTENT_B64_ENV: UNITY_2019_2_11F1_LICENSE_CONTENT_B64
 
   unity-2020-1-0b6:
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2020.1.0b6-linux-il2cpp
     environment:
-      UNITY_LICENSE_CONTENT_B64: $UNITY_2020_1_0B6_LICENSE_CONTENT_B64
+      UNITY_LICENSE_CONTENT_B64_ENV: UNITY_2020_1_0B6_LICENSE_CONTENT_B64
 
 jobs:
   build-package:
@@ -233,7 +233,7 @@ jobs:
       - run:
           name: Setup Unity license
           command: |
-            UNITY_LICENSE_CONTENT_B64="$UNITY_LICENSE_CONTENT_B64" $SCRIPTS/unity_login.sh
+            UNITY_LICENSE_CONTENT_B64="${$UNITY_LICENSE_CONTENT_B64_ENV}" $SCRIPTS/unity_login.sh
 
       - attach_workspace:
           at: /workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,11 +227,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - test-unity-upm-manifest-$UNITY_VERSION
+            - test-unity-upm-manifest-{{ .Environment.UNITY_VERSION }}
 
       - restore_cache:
           keys:
-            - test-unity-upm-global-$UNITY_VERSION
+            - test-unity-upm-global-{{ .Environment.UNITY_VERSION }}
 
       - run:
           name: Setup Unity license
@@ -275,12 +275,12 @@ jobs:
           path: ~/tests/junit
 
       - save_cache:
-          key: test-unity-upm-manifest-$UNITY_VERSION
+          key: test-unity-upm-manifest-{{ .Environment.UNITY_VERSION }}
           paths:
             - /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Library/PackageCache
 
       - save_cache:
-          key: test-unity-upm-global-$UNITY_VERSION
+          key: test-unity-upm-global-{{ .Environment.UNITY_VERSION }}
           paths:
             - /root/.config/unity3d/cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,25 @@ commands:
                 name: Setup Variables
                 command: $SCRIPTS/build_setup_variables.sh json <<parameters.update-package-json>> $REPO_FOLDER/ci/version.json
 
+executors:
+  unity-2018.4.14f1: &unity-2018.4.14f1-executor
+    docker:
+      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2018.4.14f1
+    environment:
+      UNITY_LICENSE_CONTENT_B64: $UNITY_2018_4_14F1_LICENSE_CONTENT_B64
+
+  unity-2019.2.11f1:
+    docker:
+      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2019.2.11f1
+    environment:
+      UNITY_LICENSE_CONTENT_B64: $UNITY_2019_2_11F1_LICENSE_CONTENT_B64
+
+  unity-2020.1.0b6:
+    docker:
+      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2020.1.0b6-linux-il2cpp
+    environment:
+      UNITY_LICENSE_CONTENT_B64: $UNITY_2020_1_0B6_LICENSE_CONTENT_B64
+
 jobs:
   build-package:
     working_directory: ~/repo
@@ -188,14 +207,9 @@ jobs:
   test-unity:
     parameters:
       unity-version:
-        type: string
-      unity-license-b64:
-        type: env_var_name
-        default: UNITY_LICENSE_CONTENT_B64
-      downgrade-to-unity-2018:
-        type: boolean
-        default: false
+        type: executor
 
+    executor: unity-<<parameters.unity-version>>
     working_directory: ~/repo
 
     environment:
@@ -203,9 +217,6 @@ jobs:
       ASSETS_FOLDER: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Assets
       TEST_PROJECT: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests
       PLATFORMS: playmode
-
-    docker:
-      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-<<parameters.unity-version>>
 
     steps:
       # Checkout repo -> ~/repo
@@ -222,7 +233,7 @@ jobs:
       - run:
           name: Setup Unity license
           command: |
-            UNITY_LICENSE_CONTENT_B64="${<<parameters.unity-license-b64>>}" $SCRIPTS/unity_login.sh
+            UNITY_LICENSE_CONTENT_B64="$UNITY_LICENSE_CONTENT_B64" $SCRIPTS/unity_login.sh
 
       - attach_workspace:
           at: /workspace
@@ -234,7 +245,8 @@ jobs:
             cp -vfr /workspace/testlib/. $ASSETS_FOLDER/Plugins/Newtonsoft.Json/
 
       - when:
-          condition: <<parameters.downgrade-to-unity-2018>>
+          condition:
+            equal: [ *unity-2018.4.14f1-executor, <<parameters.unity-version>> ]
           steps:
             - run:
                 name: Downgrade Unity project to 2018.x
@@ -374,22 +386,9 @@ workflows:
           requires:
             - build-package
       - test-unity:
-          name: test-unity-2018.4.14f1
-          context: unity-2018.4.14f1
-          unity-version: 2018.4.14f1
-          downgrade-to-unity-2018: true
-          requires:
-            - build-package
-      - test-unity:
-          name: test-unity-2019.2.11f1
-          context: unity-2019.2.11f1
-          unity-version: 2019.2.11f1
-          requires:
-            - build-package
-      - test-unity:
-          name: test-unity-2020.1.0b6
-          context: unity-2020.1.0b6-linux-il2cpp
-          unity-version: 2020.1.0b6-linux-il2cpp
+          matrix:
+            parameters:
+              unity-version: [ 2018.4.14f1, 2019.2.11f1, 2020.1.0b6 ]
           requires:
             - build-package
   check-deploy-ready:
@@ -408,30 +407,15 @@ workflows:
           requires:
             - build-package
       - test-unity:
-          name: test-unity-2018.4.14f1
-          context: unity-2018.4.14f1
-          unity-version: 2018.4.14f1
-          downgrade-to-unity-2018: true
-          requires:
-            - build-package
-      - test-unity:
-          name: test-unity-2019.2.11f1
-          context: unity-2019.2.11f1
-          unity-version: 2019.2.11f1
-          requires:
-            - build-package
-      - test-unity:
-          name: test-unity-2020.1.0b6
-          context: unity-2020.1.0b6-linux-il2cpp
-          unity-version: 2020.1.0b6-linux-il2cpp
+          matrix:
+            parameters:
+              unity-version: [ 2018.4.14f1, 2019.2.11f1, 2020.1.0b6 ]
           requires:
             - build-package
       - check-deploy-ready:
           requires:
             - test-windows
-            - test-unity-2018.4.14f1
-            - test-unity-2019.2.11f1
-            - test-unity-2020.1.0b6
+            - test-unity
       - deploy-cloudsmith:
           requires:
             - check-deploy-ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,17 @@ jobs:
           paths:
             - C:\Users\circleci\.nuget\packages
 
-  test-unity-2018-4-14f1:
+  test-unity:
+    parameters:
+      unity-version:
+        type: string
+      unity-license-b64:
+        type: env_var_name
+        default: UNITY_LICENSE_CONTENT_B64
+      downgrade-to-unity-2018:
+        type: boolean
+        default: false
+
     working_directory: ~/repo
 
     environment:
@@ -182,7 +192,7 @@ jobs:
       PLATFORMS: playmode
 
     docker:
-      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2018.4.14f1
+      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-<<parameters.unity-version>>
 
     steps:
       # Checkout repo -> ~/repo
@@ -190,11 +200,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - test-unity-upm-manifest-2018
+            - test-unity-upm-manifest-<<parameters.unity-version>>
 
       - restore_cache:
           keys:
-            - test-unity-upm-global-2018
+            - test-unity-upm-global-<<parameters.unity-version>>
 
       - run:
           name: Enable permissions on scripts
@@ -203,8 +213,7 @@ jobs:
       - run:
           name: Setup Unity license
           command: |
-            # Requires UNITY_2018_4_14f1_LICENSE_CONTENT_B64 environment variable to be filled in inside CircleCI
-            UNITY_LICENSE_CONTENT_B64="$UNITY_2018_4_14f1_LICENSE_CONTENT_B64" $SCRIPTS/unity_login.sh
+            UNITY_LICENSE_CONTENT_B64="<<parameters.unity-license-b64>>" $SCRIPTS/unity_login.sh
 
       - attach_workspace:
           at: /workspace
@@ -215,15 +224,18 @@ jobs:
             cp -vur /workspace/tests/. $ASSETS_FOLDER/Plugins/Newtonsoft.Json.Tests/
             cp -vfr /workspace/testlib/. $ASSETS_FOLDER/Plugins/Newtonsoft.Json/
 
-      - run:
-          name: Downgrade Unity project to 2018.x
-          command: |
-            echo "Moving $TEST_PROJECT/Packages/manifest.json file"
-            mv -v "$TEST_PROJECT/Packages/manifest.json" "$TEST_PROJECT/Packages/.manifest.json.old"
-            echo
-            find "$ASSETS_FOLDER" -name '.*.asmdef.old' -exec rm -v {} +
-            echo
-            find "$ASSETS_FOLDER" -name '*.asmdef' -exec $SCRIPTS/unity_downgrade_asmdef.sh --backup "{}" \;
+      - when:
+          condition: <<parameters.downgrade-to-unity-2018>>
+          steps:
+            - run:
+                name: Downgrade Unity project to 2018.x
+                command: |
+                  echo "Moving $TEST_PROJECT/Packages/manifest.json file"
+                  mv -v "$TEST_PROJECT/Packages/manifest.json" "$TEST_PROJECT/Packages/.manifest.json.old"
+                  echo
+                  find "$ASSETS_FOLDER" -name '.*.asmdef.old' -exec rm -v {} +
+                  echo
+                  find "$ASSETS_FOLDER" -name '*.asmdef' -exec $SCRIPTS/unity_downgrade_asmdef.sh --backup "{}" \;
 
       - run:
           name: Run tests
@@ -239,144 +251,12 @@ jobs:
           path: ~/tests/junit
 
       - save_cache:
-          key: test-unity-upm-manifest-2018
+          key: test-unity-upm-manifest-<<parameters.unity-version>>
           paths:
             - /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Library/PackageCache
 
       - save_cache:
-          key: test-unity-upm-global-2018
-          paths:
-            - /root/.config/unity3d/cache
-
-  test-unity-2019-2-11f1:
-    working_directory: ~/repo
-
-    environment:
-      SCRIPTS: /root/repo/ci/scripts
-      ASSETS_FOLDER: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Assets
-      TEST_PROJECT: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests
-      PLATFORMS: playmode
-
-    docker:
-      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2019.2.11f1
-
-    steps:
-      # Checkout repo -> ~/repo
-      - checkout
-
-      - restore_cache:
-          keys:
-            - test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Packages/manifest.json" }}
-
-      - restore_cache:
-          keys:
-            - test-unity-upm-global-2019
-
-      - run:
-          name: Enable permissions on scripts
-          command: chmod +x $SCRIPTS/**.sh -v
-
-      - run:
-          name: Setup Unity license
-          command: |
-            # Requires UNITY_2019_2_11f1_LICENSE_CONTENT_B64 environment variable to be filled in inside CircleCI
-            UNITY_LICENSE_CONTENT_B64="$UNITY_2019_2_11f1_LICENSE_CONTENT_B64" $SCRIPTS/unity_login.sh
-
-      - attach_workspace:
-          at: /workspace
-
-      - run:
-          name: Copy dll's into Unity testing project
-          command: |
-            cp -vur /workspace/tests/. $ASSETS_FOLDER/Plugins/Newtonsoft.Json.Tests/
-            cp -vfr /workspace/testlib/. $ASSETS_FOLDER/Plugins/Newtonsoft.Json/
-
-      - run:
-          name: Run tests
-          command: $SCRIPTS/unity_test.sh $TEST_PROJECT ~/tests/nunit
-
-      - run:
-          name: Convert NUnit to JUnit xml
-          when: always
-          command: $SCRIPTS/nunit2junit.sh ~/tests/nunit ~/tests/junit/
-
-      - store_test_results:
-          name: Store test results -> ~/tests/junit
-          path: ~/tests/junit
-
-      - save_cache:
-          key: test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Packages/manifest.json" }}
-          paths:
-            - /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Library/PackageCache
-
-      - save_cache:
-          key: test-unity-upm-global-2019
-          paths:
-            - /root/.config/unity3d/cache
-
-  test-unity-2020-1-0b6:
-    working_directory: ~/repo
-    
-    environment:
-      SCRIPTS: /root/repo/ci/scripts
-      ASSETS_FOLDER: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Assets
-      TEST_PROJECT: /root/repo/Src/Newtonsoft.Json-for-Unity.Tests
-      PLATFORMS: playmode
-
-    docker:
-      - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2020.1.0b6-linux-il2cpp
-
-    steps:
-      # Checkout repo -> ~/repo
-      - checkout
-
-      - restore_cache:
-          keys:
-            - test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Packages/manifest.json" }}
-
-      - restore_cache:
-          keys:
-            - test-unity-upm-global-2020
-
-      - run:
-          name: Enable permissions on scripts
-          command: chmod +x $SCRIPTS/**.sh -v
-
-      - run:
-          name: Setup Unity license
-          command: |
-            # Requires UNITY_2020_1_0b6_LICENSE_CONTENT_B64 environment variable to be filled in inside CircleCI
-            UNITY_LICENSE_CONTENT_B64="$UNITY_2020_1_0b6_LICENSE_CONTENT_B64" $SCRIPTS/unity_login.sh
-
-      - attach_workspace:
-          at: /workspace
-
-      - run:
-          name: Copy dll's into Unity testing project
-          command: |
-            cp -vur /workspace/tests/. $ASSETS_FOLDER/Plugins/Newtonsoft.Json.Tests/
-            cp -vfr /workspace/testlib/. $ASSETS_FOLDER/Plugins/Newtonsoft.Json/
-
-      - run:
-          name: Run tests
-          command: $SCRIPTS/unity_test.sh $TEST_PROJECT ~/tests/nunit
-
-      - run:
-          name: Convert NUnit to JUnit xml
-          when: always
-          command: $SCRIPTS/nunit2junit.sh ~/tests/nunit ~/tests/junit/
-
-      - store_test_results:
-          name: Store test results -> ~/tests/junit
-          path: ~/tests/junit
-
-      - save_cache:
-          key: test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Packages/manifest.json" }}
-          paths:
-            - /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Library/PackageCache
-
-      - save_cache:
-          key: test-unity-upm-global-2020
+          key: test-unity-upm-global-<<parameters.unity-version>>
           paths:
             - /root/.config/unity3d/cache
 
@@ -505,13 +385,23 @@ workflows:
       - test-windows:
           requires:
             - build-package
-      - test-unity-2018-4-14f1:
+      - test-unity:
+          name: test-unity-2018.4.14f1
+          context: unity-2018.4.14f1
+          unity-version: 2018.4.14f1
+          downgrade-to-unity-2018: true
           requires:
             - build-package
-      - test-unity-2019-2-11f1:
+      - test-unity:
+          name: test-unity-2019.2.11f1
+          context: unity-2019.2.11f1
+          unity-version: 2019.2.11f1
           requires:
             - build-package
-      - test-unity-2020-1-0b6:
+      - test-unity:
+          name: test-unity-2020.1.0b6
+          context: unity-2020.1.0b6-linux-il2cpp
+          unity-version: 2020.1.0b6-linux-il2cpp
           requires:
             - build-package
   check-deploy-ready:
@@ -529,21 +419,31 @@ workflows:
       - test-windows:
           requires:
             - build-package
-      - test-unity-2018-4-14f1:
+      - test-unity:
+          name: test-unity-2018.4.14f1
+          context: unity-2018.4.14f1
+          unity-version: 2018.4.14f1
+          downgrade-to-unity-2018: true
           requires:
             - build-package
-      - test-unity-2019-2-11f1:
+      - test-unity:
+          name: test-unity-2019.2.11f1
+          context: unity-2019.2.11f1
+          unity-version: 2019.2.11f1
           requires:
             - build-package
-      - test-unity-2020-1-0b6:
+      - test-unity:
+          name: test-unity-2020.1.0b6
+          context: unity-2020.1.0b6-linux-il2cpp
+          unity-version: 2020.1.0b6-linux-il2cpp
           requires:
             - build-package
       - check-deploy-ready:
           requires:
             - test-windows
-            - test-unity-2018-4-14f1
-            - test-unity-2019-2-11f1
-            - test-unity-2020-1-0b6
+            - test-unity-2018.4.14f1
+            - test-unity-2019.2.11f1
+            - test-unity-2020.1.0b6
       - deploy-cloudsmith:
           requires:
             - check-deploy-ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity/Packages/manifest.json" }}
+            - test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Packages/manifest.json" }}
             - test-unity-upm-manifest
 
       - restore_cache:
@@ -280,7 +280,7 @@ jobs:
           path: ~/tests/junit
 
       - save_cache:
-          key: test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity/Packages/manifest.json" }}
+          key: test-unity-upm-manifest-{{ checksum "/root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Packages/manifest.json" }}
           paths:
             - /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Library/PackageCache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
       - run:
           name: Setup Unity license
           command: |
-            UNITY_LICENSE_CONTENT_B64="<<parameters.unity-license-b64>>" $SCRIPTS/unity_login.sh
+            UNITY_LICENSE_CONTENT_B64="${<<parameters.unity-license-b64>>}" $SCRIPTS/unity_login.sh
 
       - attach_workspace:
           at: /workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
           paths:
             - C:\Users\circleci\.nuget\packages
 
-  test-unity:
+  test:
     parameters:
       unity-version:
         type: executor
@@ -393,7 +393,7 @@ workflows:
       - test-windows:
           requires:
             - build-package
-      - test-unity:
+      - test:
           matrix:
             parameters:
               unity-version: [ unity-2018-4-14f1, unity-2019-2-11f1, unity-2020-1-0b6 ]
@@ -414,7 +414,7 @@ workflows:
       - test-windows:
           requires:
             - build-package
-      - test-unity:
+      - test:
           matrix:
             parameters:
               unity-version: [ unity-2018-4-14f1, unity-2019-2-11f1, unity-2020-1-0b6 ]
@@ -423,7 +423,7 @@ workflows:
       - check-deploy-ready:
           requires:
             - test-windows
-            - test-unity
+            - test
       - deploy-cloudsmith:
           requires:
             - check-deploy-ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,18 +48,21 @@ executors:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2018.4.14f1
     environment:
       UNITY_LICENSE_CONTENT_B64_ENV: UNITY_2018_4_14F1_LICENSE_CONTENT_B64
+      UNITY_VERSION: 2018.4.14f1
 
   unity-2019-2-11f1:
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2019.2.11f1
     environment:
       UNITY_LICENSE_CONTENT_B64_ENV: UNITY_2019_2_11F1_LICENSE_CONTENT_B64
+      UNITY_VERSION: 2019.2.11f1
 
   unity-2020-1-0b6:
     docker:
       - image: applejag/newtonsoft.json-for-unity.package-unity-tester:v1-2020.1.0b6-linux-il2cpp
     environment:
       UNITY_LICENSE_CONTENT_B64_ENV: UNITY_2020_1_0B6_LICENSE_CONTENT_B64
+      UNITY_VERSION: 2020.1.0b6
 
 jobs:
   build-package:
@@ -224,11 +227,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - test-unity-upm-manifest-<<parameters.unity-version>>
+            - test-unity-upm-manifest-$UNITY_VERSION
 
       - restore_cache:
           keys:
-            - test-unity-upm-global-<<parameters.unity-version>>
+            - test-unity-upm-global-$UNITY_VERSION
 
       - run:
           name: Setup Unity license
@@ -272,12 +275,12 @@ jobs:
           path: ~/tests/junit
 
       - save_cache:
-          key: test-unity-upm-manifest-<<parameters.unity-version>>
+          key: test-unity-upm-manifest-$UNITY_VERSION
           paths:
             - /root/repo/Src/Newtonsoft.Json-for-Unity.Tests/Library/PackageCache
 
       - save_cache:
-          key: test-unity-upm-global-<<parameters.unity-version>>
+          key: test-unity-upm-global-$UNITY_VERSION
           paths:
             - /root/.config/unity3d/cache
 


### PR DESCRIPTION
The CircleCI job is unbearingly long and convoluted as-is. This is my attempts at simplifying it as best I can.

## Changes

- Removed the 3 different jobs for different Unity versions, in favor of 1 job with parameters.
- Added checkout-and-setup command to reduce more duplication
- Using matrix job and executors to run the different unity versions