### PR TITLE
Backport note in "Features"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ and portable .NET **(UWP, WP8)**.
 
 ## Features
 
-- *(🌟 new!)* Backported! Provides Newtonsoft.Json v10.0.3, v11.0.2, v12.0.3, and
-  v13.0.1 alternatives.
+- *(🌟 new!)* Backported! Provides Newtonsoft.Json v10.0.3, v11.0.2, v12.0.3,
+  and v13.0.1 alternatives.
 
 - [Newtonsoft.Json-for-Unity.Converters][json.net-4-unity.converters]
   package for converting Unity types, such as the Vector3, Quaternion, Color,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ and portable .NET **(UWP, WP8)**.
 
 ## Features
 
-- *(🌟 new!)* [Newtonsoft.Json-for-Unity.Converters][json.net-4-unity.converters]
+- *(🌟 new!)* Backported! Provides Newtonsoft.Json v10.0.3, v11.0.2, v12.0.3, and
+  v13.0.1 alternatives.
+
+- [Newtonsoft.Json-for-Unity.Converters][json.net-4-unity.converters]
   package for converting Unity types, such as the Vector3, Quaternion, Color,
   and [many, many more!][json.net-4-unity.converters-compatability]
 


### PR DESCRIPTION
The converters package isn't that new anymore. The latest feature is that it now supports Newtonsoft.Json 10.0.x to 13.0.x.

